### PR TITLE
Allow display of news from other sites

### DIFF
--- a/Configuration/NodeTypes.Content.NewsLatest.yaml
+++ b/Configuration/NodeTypes.Content.NewsLatest.yaml
@@ -1,6 +1,7 @@
 'Community.News:NewsLatest':
   superTypes:
     'Neos.Neos:Content': true
+    'Community.News:Mixin.VirtualNewsAware': true
   constraints:
     nodeTypes:
       '*': false

--- a/Configuration/NodeTypes.Content.NewsList.yaml
+++ b/Configuration/NodeTypes.Content.NewsList.yaml
@@ -1,6 +1,7 @@
 'Community.News:NewsList':
   superTypes:
     'Neos.Neos:Content': true
+    'Community.News:Mixin.VirtualNewsAware': true
   constraints:
     nodeTypes:
       '*': false

--- a/Configuration/NodeTypes.Document.Category.yaml
+++ b/Configuration/NodeTypes.Document.Category.yaml
@@ -1,6 +1,7 @@
 'Community.News:Category':
   superTypes:
     'Neos.Neos:Document': true
+    'Community.News:Mixin.VirtualNewsAware': true
   constraints:
     nodeTypes:
       '*': false

--- a/Configuration/NodeTypes.Document.VirtualNews.yaml
+++ b/Configuration/NodeTypes.Document.VirtualNews.yaml
@@ -1,0 +1,10 @@
+'Community.News:VirtualNews':
+  superTypes:
+    'Neos.Neos:Document': true
+  constraints:
+    nodeTypes:
+      '*': false
+  ui:
+    label: 'Virtual News Display'
+    icon: 'icon-ghost'
+    group: 'news'

--- a/Configuration/NodeTypes.Mixin.VirtualNewsAware.yaml
+++ b/Configuration/NodeTypes.Mixin.VirtualNewsAware.yaml
@@ -1,0 +1,19 @@
+'Community.News:Mixin.VirtualNewsAware':
+  abstract: true
+  ui:
+    inspector:
+      groups:
+        display:
+          label: 'Display'
+          position: 10
+  properties:
+    virtualNews:
+      type: reference
+      ui:
+        label: 'Virtual News Document'
+        reloadIfChanged: true
+        inspector:
+          group: 'display'
+          position: 10
+          editorOptions:
+            nodeTypes: [ 'Community.News:VirtualNews' ]

--- a/Resources/Private/Fusion/NodeTypes/Category.fusion
+++ b/Resources/Private/Fusion/NodeTypes/Category.fusion
@@ -10,7 +10,10 @@ prototype(Community.News:Category) < prototype(Neos.Neos:Page) {
 
         # Fetch and render all news articles that belong to the current category
         newsByCategory = Community.News:AbstractList {
-            @context.listTitle = 'News with this category'
+            @context {
+                listTitle = 'News with this category'
+                virtualNewsNode = ${q(node).property('virtualNews')}
+            }
             prototype(Flowpack.Listable:PaginatedCollection) {
                 @context.paginationEnabled = false
                 collection = ${q(site).find('[instanceof Community.News:AbstractNews]').filterByReference('categories', node).get()}

--- a/Resources/Private/Fusion/NodeTypes/News.Short.fusion
+++ b/Resources/Private/Fusion/NodeTypes/News.Short.fusion
@@ -7,4 +7,7 @@ prototype(Community.News:News.Short) < prototype(Neos.Neos:Content) {
     title = ${q(node).property('title')}
     teaser = ${q(node).property('teaser')}
     author = ${q(node).property('author')}
+
+    # from context
+    virtualNewsNode = ${virtualNewsNode}
 }

--- a/Resources/Private/Fusion/NodeTypes/NewsLatest.fusion
+++ b/Resources/Private/Fusion/NodeTypes/NewsLatest.fusion
@@ -2,6 +2,8 @@ prototype(Community.News:NewsLatest) < prototype(Neos.Neos:ContentComponent) {
     renderer.@context.category = ${q(node).property('category')}
 
     renderer = Community.News:AbstractList {
+        @context.virtualNewsNode = ${q(node).property('virtualNews')}
+
         collection = ${q(site).find('[instanceof Community.News:News]').get()}
         collection.@process.filter = ${category == null ? value : Array.filter(value, node => Array.indexOf(node.properties.categories,category) != -1)}
         collection.@process.sort = ${q(value).count() > 0 ? q(value).sort('publishDate', 'DESC').slice(0, 3).get() : value}

--- a/Resources/Private/Fusion/NodeTypes/NewsList.fusion
+++ b/Resources/Private/Fusion/NodeTypes/NewsList.fusion
@@ -2,6 +2,8 @@ prototype(Community.News:NewsList) < prototype(Neos.Neos:ContentComponent) {
     renderer.@context.category = ${q(node).property('category')}
 
     renderer = Community.News:AbstractList {
+        @context.virtualNewsNode = ${q(node).property('virtualNews')}
+
         collection = ${q(site).find('[instanceof Community.News:News]').get()}
         collection.@process.filter = ${category == null ? value : Array.filter(value, node => Array.indexOf(node.properties.categories,category) != -1)}
         collection.@process.sort = ${q(value).count() > 0 ? q(value).sort('publishDate', 'DESC').slice(0, 3).get() : value}

--- a/Resources/Private/Fusion/NodeTypes/VirtualNews.fusion
+++ b/Resources/Private/Fusion/NodeTypes/VirtualNews.fusion
@@ -1,0 +1,23 @@
+prototype(Community.News:VirtualNews) < prototype(Community.News:News) {
+    body.@context.newsNode = ${q(site).find('#' + request.arguments.news).get(0)}
+    body {
+        title = ${q(newsNode).property('title')}
+        publishDate = ${q(newsNode).property('publishDate')}
+        teaser = ${q(newsNode).property('teaser')}
+        author = ${q(newsNode).property('author')}
+
+        main.@context.node = ${newsNode}
+        categories.collection = ${q(newsNode).property('categories')}
+        relatedNews.@context.node = ${newsNode}
+    }
+
+    @cache {
+        mode = 'dynamic'
+        context {
+            1 = 'site'
+            2 = 'documentNode'
+            3 = 'node'
+        }
+        entryDiscriminator = ${request.arguments.news}
+    }
+}

--- a/Resources/Private/Templates/NodeTypes/News.Short.html
+++ b/Resources/Private/Templates/NodeTypes/News.Short.html
@@ -1,6 +1,19 @@
 {namespace neos=Neos\Neos\ViewHelpers}
 
-<neos:link.node node="{node}">
+<f:if condition="{virtualNewsNode}">
+    <f:then>
+        <neos:link.node node="{virtualNewsNode}" arguments="{node: node}">
+            <f:render section="content"/>
+        </neos:link.node>
+    </f:then>
+    <f:else>
+        <neos:link.node node="{node}">
+            <f:render section="content"/>
+        </neos:link.node>
+    </f:else>
+</f:if>
+
+<f:section name="content">
     <!-- Creation Date -->
     <p><f:format.date date="{publishDate}" format="d.m.Y H:i" /></p>
 
@@ -14,4 +27,4 @@
     <f:if condition="{author}">
         <p>{author.properties.title}</p>
     </f:if>
-</neos:link.node>
+</f:section>


### PR DESCRIPTION
The new "Virtual News Display" document type allows to render news
coming from nodes outside the current site.

Add it somewhere to you document tree and then set the "Virtual News
Document" property on categories, latest news or news list that should
be using it.